### PR TITLE
Issue#6

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,9 +211,7 @@ All env vars are available in javascript filters scope. You can list them by cal
 
 **WARNING** this may change soon. We are not comfortable with this solution as is.
 
-The routes are duplicated, one version with a `/token/{token}` prefixed and another version without the token prefix.
-
-In our case, this was used in conjunction with a CLI that logs the user in and changes the DOCKER_HOST env var in the user machine to our go-horse address with the token added in its path. The first filter - with order equals 0, extract the token, validates the user and rewrite the URL calling `ctx.values.set('path', '<tokenless_url>')`.
+Authentication should be handled by **filters**. The authentication token must be sent to Go Horse Proxy by query parameter or request headers.
 
 Another possible solution, and more elegant - I think, is to insert a token as a header in all docker CLI commands requests. This can be achieved by editing /~/.docker/config.json file, inserting the property `"HttpHeaders": { "token": "?" },`. The request to docker daemon will carry the token in its headers and a filter can read and validate it - sending a request to an identity manager? Maybe.
 

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,8 @@ require (
 	github.com/klauspost/cpuid v1.2.1 // indirect
 	github.com/mattn/go-colorable v0.1.4 // indirect
 	github.com/microcosm-cc/bluemonday v1.0.2 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/moul/http2curl v1.0.0 // indirect
 	github.com/onsi/ginkgo v1.10.2 // indirect
 	github.com/onsi/gomega v1.7.0 // indirect

--- a/web/middleware/filter.go
+++ b/web/middleware/filter.go
@@ -33,7 +33,7 @@ func ResquestFilter(filter * filters.FilterManager) context.Handler {
 
 		ctx.Values().Set("path", ctx.Request().URL.Path)
 
-		_, err := filter.RunRequestFilters(ctx, RequestBodyKey)
+		result , err := filter.RunRequestFilters(ctx, RequestBodyKey)
 
 		writer := ctx.ResponseWriter()
 		ctx.ResetResponseWriter(writer)
@@ -46,6 +46,9 @@ func ResquestFilter(filter * filters.FilterManager) context.Handler {
 			ctx.StopExecution()
 			return
 		}
-		ctx.Next()
+
+		if result.Next{
+			ctx.Next()
+		}
 	}
 }

--- a/web/web.go
+++ b/web/web.go
@@ -63,16 +63,6 @@ func (s *Server) Run() error {
 
 	app.Use(middleware.ResquestFilter(s.Filter))
 
-	//TODO mapear rota para receber token ou nao
-	authToken := app.Party("/token/{token:string}/")
-	authToken.Post("/{version:string}/containers/{containerId:string}/attach", s.AttachAPIs.AttachHandler)
-	authToken.Get("/{version:string}/containers/{id:string}/logs", s.LogsAPIs.LogsHandler).Name = "container-logs"
-	authToken.Get("/{version:string}/services/{id:string}/logs", s.LogsAPIs.LogsHandler).Name = "service-logs"
-	authToken.Post("/{version:string}/containers/{containerId:string}/wait", s.WaitAPIs.WaitHandler)
-	authToken.Post("/{version:string}/exec/{execInstanceId:string}/start", s.ExecAPIs.ExecHandler)
-	authToken.Get("/{version:string}/containers/{containerId:string}/stats", s.StatsAPIs.StatsHandler)
-	authToken.Get("/{version:string}/events", s.EventsAPIs.EventsHandler)
-
 	app.Post("/{version:string}/containers/{containerId:string}/attach", s.AttachAPIs.AttachHandler)
 	app.Get("/{version:string}/containers/{id:string}/logs", s.LogsAPIs.LogsHandler).Name = "container-logs"
 	app.Get("/{version:string}/services/{id:string}/logs", s.LogsAPIs.LogsHandler).Name = "service-logs"


### PR DESCRIPTION
fixed #6 

`ResquestFilter` middleware should analyse the `result.Next` attribute from `RunRequestFilters` method, so if the `Next` attribute is `true` then calls the `ctx.Next()` method.